### PR TITLE
get correct field name in struct tag

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
+	"strings"
 )
 
 type cachedField struct {
@@ -74,6 +75,10 @@ func (s *structCacheMap) parseStruct(mode Mode, current reflect.Value, key refle
 
 		if name = fld.Tag.Get(tagName); name == ignore {
 			continue
+		}
+
+		if commaIndex := strings.Index(name, ","); commaIndex != -1 {
+			name = name[:commaIndex]
 		}
 
 		if mode == ModeExplicit && len(name) == 0 {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1451,3 +1451,25 @@ func TestDecoderExplicit(t *testing.T) {
 	Equal(t, test.Name, "Joeybloggs")
 	Equal(t, test.Age, 0)
 }
+
+func TestDecoderStructWithJSONTag(t *testing.T) {
+	type Test struct {
+		Name string `json:"name,omitempty"`
+		Age  int    `json:",omitempty"`
+	}
+
+	values := map[string][]string{
+		"name": {"Joeybloggs"},
+		"Age":  {"3"},
+	}
+
+	var test Test
+
+	d := NewDecoder()
+	d.SetTagName("json")
+
+	err := d.Decode(&test, values)
+	Equal(t, err, nil)
+	Equal(t, test.Name, "Joeybloggs")
+	Equal(t, test.Age, int(3))
+}


### PR DESCRIPTION
this fix will correct code of detecting field name in struct tag. JSON tag in struct is usually in this format:
```go
type RequestInput struct {
   Query string `json:"query,omitempty"`
}
```
we need to get correct json field name `query` instead of `query,omitempty`