### PR TITLE
Add RegisterTagNameFunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Package form
 ============
 <img align="right" src="https://raw.githubusercontent.com/go-playground/form/master/logo.jpg">
-![Project status](https://img.shields.io/badge/version-2.2.2-green.svg)
+![Project status](https://img.shields.io/badge/version-2.3.0-green.svg)
 [![Build Status](https://semaphoreci.com/api/v1/joeybloggs/form/branches/master/badge.svg)](https://semaphoreci.com/joeybloggs/form)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/form/badge.svg?branch=master)](https://coveralls.io/github/go-playground/form?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/form)](https://goreportcard.com/report/github.com/go-playground/form)
@@ -266,7 +266,7 @@ Field []*string{nil, nil, &i}
 
 Benchmarks
 ------
-###### Run on MacBook Pro (Retina, 15-inch, Late 2013) 2.6 GHz Intel Core i7 16 GB 1600 MHz DDR3 using Go version go1.7 darwin/amd64
+###### Run on i5-7600 16 GB DDR4-2400 using Go version go1.7.5 linux/amd64
 
 NOTE: the 1 allocation and B/op in the first 4 decodes is actually the struct allocating when passing it in, so primitives are actually zero allocation.
 
@@ -274,26 +274,26 @@ NOTE: the 1 allocation and B/op in the first 4 decodes is actually the struct al
 go test -bench=. -benchmem=true
 
 PASS
-BenchmarkSimpleUserDecodeStruct-8                              	 5000000       	       312 ns/op       	      64 B/op  	       1 allocs/op
-BenchmarkSimpleUserDecodeStructParallel-8                      	20000000       	        91.7 ns/op     	      64 B/op  	       1 allocs/op
-BenchmarkSimpleUserEncodeStruct-8                              	 2000000       	       902 ns/op       	     485 B/op  	      11 allocs/op
-BenchmarkSimpleUserEncodeStructParallel-8                      	 5000000       	       301 ns/op       	     485 B/op  	      11 allocs/op
-BenchmarkPrimitivesDecodeStructAllPrimitivesTypes-8            	 2000000       	      1028 ns/op       	      96 B/op  	       1 allocs/op
-BenchmarkPrimitivesDecodeStructAllPrimitivesTypesParallel-8    	 5000000       	       292 ns/op       	      96 B/op  	       1 allocs/op
-BenchmarkPrimitivesEncodeStructAllPrimitivesTypes-8            	  300000       	      4770 ns/op       	    3009 B/op  	      46 allocs/op
-BenchmarkPrimitivesEncodeStructAllPrimitivesTypesParallel-8    	 1000000       	      1569 ns/op       	    3010 B/op  	      46 allocs/op
-BenchmarkComplexArrayDecodeStructAllTypes-8                    	  100000       	     15973 ns/op       	    2257 B/op  	     121 allocs/op
-BenchmarkComplexArrayDecodeStructAllTypesParallel-8            	  300000       	      4801 ns/op       	    2257 B/op  	     121 allocs/op
-BenchmarkComplexArrayEncodeStructAllTypes-8                    	  100000       	     15401 ns/op       	    7289 B/op  	     146 allocs/op
-BenchmarkComplexArrayEncodeStructAllTypesParallel-8            	  300000       	      5167 ns/op       	    7289 B/op  	     146 allocs/op
-BenchmarkComplexMapDecodeStructAllTypes-8                      	   50000       	     20683 ns/op       	    5307 B/op  	     130 allocs/op
-BenchmarkComplexMapDecodeStructAllTypesParallel-8              	  300000       	      6880 ns/op       	    5310 B/op  	     130 allocs/op
-BenchmarkComplexMapEncodeStructAllTypes-8                      	  100000       	     15567 ns/op       	    7098 B/op  	     175 allocs/op
-BenchmarkComplexMapEncodeStructAllTypesParallel-8              	  300000       	      5546 ns/op       	    7099 B/op  	     175 allocs/op
-BenchmarkDecodeNestedStruct-8                                  	  500000       	      3142 ns/op       	     384 B/op  	      14 allocs/op
-BenchmarkDecodeNestedStructParallel-8                          	 1000000       	      1012 ns/op       	     384 B/op  	      14 allocs/op
-BenchmarkEncodeNestedStruct-8                                  	 1000000       	      2106 ns/op       	     704 B/op  	      16 allocs/op
-BenchmarkEncodeNestedStructParallel-8                          	 2000000       	       772 ns/op       	     704 B/op  	      16 allocs/op
+BenchmarkSimpleUserDecodeStruct-4                                    	 5000000	       252 ns/op	      64 B/op	       1 allocs/op
+BenchmarkSimpleUserDecodeStructParallel-4                            	20000000	        74.1 ns/op	      64 B/op	       1 allocs/op
+BenchmarkSimpleUserEncodeStruct-4                                    	 2000000	       800 ns/op	     485 B/op	      11 allocs/op
+BenchmarkSimpleUserEncodeStructParallel-4                            	10000000	       220 ns/op	     485 B/op	      11 allocs/op
+BenchmarkPrimitivesDecodeStructAllPrimitivesTypes-4                  	 2000000	       773 ns/op	      96 B/op	       1 allocs/op
+BenchmarkPrimitivesDecodeStructAllPrimitivesTypesParallel-4          	10000000	       225 ns/op	      96 B/op	       1 allocs/op
+BenchmarkPrimitivesEncodeStructAllPrimitivesTypes-4                  	  300000	      4330 ns/op	    3009 B/op	      46 allocs/op
+BenchmarkPrimitivesEncodeStructAllPrimitivesTypesParallel-4          	 1000000	      1131 ns/op	    3009 B/op	      46 allocs/op
+BenchmarkComplexArrayDecodeStructAllTypes-4                          	  100000	     13316 ns/op	    2256 B/op	     121 allocs/op
+BenchmarkComplexArrayDecodeStructAllTypesParallel-4                  	  300000	      3980 ns/op	    2256 B/op	     121 allocs/op
+BenchmarkComplexArrayEncodeStructAllTypes-4                          	  100000	     14038 ns/op	    7287 B/op	     146 allocs/op
+BenchmarkComplexArrayEncodeStructAllTypesParallel-4                  	  300000	      3646 ns/op	    7288 B/op	     146 allocs/op
+BenchmarkComplexMapDecodeStructAllTypes-4                            	  100000	     18042 ns/op	    5305 B/op	     130 allocs/op
+BenchmarkComplexMapDecodeStructAllTypesParallel-4                    	  300000	      5051 ns/op	    5306 B/op	     130 allocs/op
+BenchmarkComplexMapEncodeStructAllTypes-4                            	  100000	     14177 ns/op	    7098 B/op	     175 allocs/op
+BenchmarkComplexMapEncodeStructAllTypesParallel-4                    	  300000	      3693 ns/op	    7098 B/op	     175 allocs/op
+BenchmarkDecodeNestedStruct-4                                        	  500000	      2762 ns/op	     384 B/op	      14 allocs/op
+BenchmarkDecodeNestedStructParallel-4                                	 2000000	       785 ns/op	     384 B/op	      14 allocs/op
+BenchmarkEncodeNestedStruct-4                                        	 1000000	      1779 ns/op	     704 B/op	      16 allocs/op
+BenchmarkEncodeNestedStructParallel-4                                	 3000000	       493 ns/op	     704 B/op	      16 allocs/op
 ```
 
 Competitor benchmarks can be found [here](https://github.com/go-playground/form/blob/master/benchmarks/benchmarks.md)

--- a/benchmarks/benchmarks.md
+++ b/benchmarks/benchmarks.md
@@ -1,84 +1,86 @@
 ## Benchmarks
 
-Competitor Benchmarks Last Run Aug 23, 2016
+Competitor Benchmarks Last Run Feb 15, 2017
+
+Run on i5-7600 16 GB DDR4-2400 using Go version go1.7.5 linux/amd64
 
 ### go-playground/form
 ```go
 PASS
-BenchmarkSimpleUserDecodeStruct-8                              	 5000000       	       312 ns/op       	      64 B/op  	       1 allocs/op
-BenchmarkSimpleUserDecodeStructParallel-8                      	20000000       	        91.7 ns/op     	      64 B/op  	       1 allocs/op
-BenchmarkSimpleUserEncodeStruct-8                              	 2000000       	       902 ns/op       	     485 B/op  	      11 allocs/op
-BenchmarkSimpleUserEncodeStructParallel-8                      	 5000000       	       301 ns/op       	     485 B/op  	      11 allocs/op
-BenchmarkPrimitivesDecodeStructAllPrimitivesTypes-8            	 2000000       	      1028 ns/op       	      96 B/op  	       1 allocs/op
-BenchmarkPrimitivesDecodeStructAllPrimitivesTypesParallel-8    	 5000000       	       292 ns/op       	      96 B/op  	       1 allocs/op
-BenchmarkPrimitivesEncodeStructAllPrimitivesTypes-8            	  300000       	      4770 ns/op       	    3009 B/op  	      46 allocs/op
-BenchmarkPrimitivesEncodeStructAllPrimitivesTypesParallel-8    	 1000000       	      1569 ns/op       	    3010 B/op  	      46 allocs/op
-BenchmarkComplexArrayDecodeStructAllTypes-8                    	  100000       	     15973 ns/op       	    2257 B/op  	     121 allocs/op
-BenchmarkComplexArrayDecodeStructAllTypesParallel-8            	  300000       	      4801 ns/op       	    2257 B/op  	     121 allocs/op
-BenchmarkComplexArrayEncodeStructAllTypes-8                    	  100000       	     15401 ns/op       	    7289 B/op  	     146 allocs/op
-BenchmarkComplexArrayEncodeStructAllTypesParallel-8            	  300000       	      5167 ns/op       	    7289 B/op  	     146 allocs/op
-BenchmarkComplexMapDecodeStructAllTypes-8                      	   50000       	     20683 ns/op       	    5307 B/op  	     130 allocs/op
-BenchmarkComplexMapDecodeStructAllTypesParallel-8              	  300000       	      6880 ns/op       	    5310 B/op  	     130 allocs/op
-BenchmarkComplexMapEncodeStructAllTypes-8                      	  100000       	     15567 ns/op       	    7098 B/op  	     175 allocs/op
-BenchmarkComplexMapEncodeStructAllTypesParallel-8              	  300000       	      5546 ns/op       	    7099 B/op  	     175 allocs/op
-BenchmarkDecodeNestedStruct-8                                  	  500000       	      3142 ns/op       	     384 B/op  	      14 allocs/op
-BenchmarkDecodeNestedStructParallel-8                          	 1000000       	      1012 ns/op       	     384 B/op  	      14 allocs/op
-BenchmarkEncodeNestedStruct-8                                  	 1000000       	      2106 ns/op       	     704 B/op  	      16 allocs/op
-BenchmarkEncodeNestedStructParallel-8                          	 2000000       	       772 ns/op       	     704 B/op  	      16 allocs/op
+BenchmarkSimpleUserDecodeStruct-4                                    	 5000000	       252 ns/op	      64 B/op	       1 allocs/op
+BenchmarkSimpleUserDecodeStructParallel-4                            	20000000	        74.1 ns/op	      64 B/op	       1 allocs/op
+BenchmarkSimpleUserEncodeStruct-4                                    	 2000000	       800 ns/op	     485 B/op	      11 allocs/op
+BenchmarkSimpleUserEncodeStructParallel-4                            	10000000	       220 ns/op	     485 B/op	      11 allocs/op
+BenchmarkPrimitivesDecodeStructAllPrimitivesTypes-4                  	 2000000	       773 ns/op	      96 B/op	       1 allocs/op
+BenchmarkPrimitivesDecodeStructAllPrimitivesTypesParallel-4          	10000000	       225 ns/op	      96 B/op	       1 allocs/op
+BenchmarkPrimitivesEncodeStructAllPrimitivesTypes-4                  	  300000	      4330 ns/op	    3009 B/op	      46 allocs/op
+BenchmarkPrimitivesEncodeStructAllPrimitivesTypesParallel-4          	 1000000	      1131 ns/op	    3009 B/op	      46 allocs/op
+BenchmarkComplexArrayDecodeStructAllTypes-4                          	  100000	     13316 ns/op	    2256 B/op	     121 allocs/op
+BenchmarkComplexArrayDecodeStructAllTypesParallel-4                  	  300000	      3980 ns/op	    2256 B/op	     121 allocs/op
+BenchmarkComplexArrayEncodeStructAllTypes-4                          	  100000	     14038 ns/op	    7287 B/op	     146 allocs/op
+BenchmarkComplexArrayEncodeStructAllTypesParallel-4                  	  300000	      3646 ns/op	    7288 B/op	     146 allocs/op
+BenchmarkComplexMapDecodeStructAllTypes-4                            	  100000	     18042 ns/op	    5305 B/op	     130 allocs/op
+BenchmarkComplexMapDecodeStructAllTypesParallel-4                    	  300000	      5051 ns/op	    5306 B/op	     130 allocs/op
+BenchmarkComplexMapEncodeStructAllTypes-4                            	  100000	     14177 ns/op	    7098 B/op	     175 allocs/op
+BenchmarkComplexMapEncodeStructAllTypesParallel-4                    	  300000	      3693 ns/op	    7098 B/op	     175 allocs/op
+BenchmarkDecodeNestedStruct-4                                        	  500000	      2762 ns/op	     384 B/op	      14 allocs/op
+BenchmarkDecodeNestedStructParallel-4                                	 2000000	       785 ns/op	     384 B/op	      14 allocs/op
+BenchmarkEncodeNestedStruct-4                                        	 1000000	      1779 ns/op	     704 B/op	      16 allocs/op
+BenchmarkEncodeNestedStructParallel-4                                	 3000000	       493 ns/op	     704 B/op	      16 allocs/op
 ```
 
 ### gorilla/schema
 ```go
-BenchmarkSimpleUserStructGorilla-8                                     	  500000       	      2412 ns/op       	     520 B/op  	      23 allocs/op
-BenchmarkSimpleUserStructGorillaParallel-8                             	 2000000       	       900 ns/op       	     520 B/op  	      23 allocs/op
-BenchmarkPrimitivesStructAllPrimitivesTypesGorilla-8                   	  200000       	      9495 ns/op       	    1536 B/op  	      84 allocs/op
-BenchmarkPrimitivesStructAllPrimitivesTypesGorillaParallel-8           	  500000       	      3018 ns/op       	    1536 B/op  	      84 allocs/op
-BenchmarkComplexArrayStructAllTypesGorilla-8                           	   50000       	     29454 ns/op       	    5416 B/op  	     223 allocs/op
-BenchmarkComplexArrayStructAllTypesGorillaParallel-8                   	  200000       	      9406 ns/op       	    5416 B/op  	     223 allocs/op
-BenchmarkArrayMapNestedStructGorilla-8                                 	  200000       	     10212 ns/op       	    2285 B/op  	      75 allocs/op
-BenchmarkArrayMapNestedStructGorillaParallel-8                         	  500000       	      3305 ns/op       	    2285 B/op  	      75 allocs/op
+BenchmarkSimpleUserStructGorilla-4                                   	 1000000	      2077 ns/op	     520 B/op	      23 allocs/op
+BenchmarkSimpleUserStructGorillaParallel-4                           	 2000000	       667 ns/op	     520 B/op	      23 allocs/op
+BenchmarkPrimitivesStructAllPrimitivesTypesGorilla-4                 	  200000	      7997 ns/op	    1536 B/op	      84 allocs/op
+BenchmarkPrimitivesStructAllPrimitivesTypesGorillaParallel-4         	  500000	      2429 ns/op	    1536 B/op	      84 allocs/op
+BenchmarkComplexArrayStructAllTypesGorilla-4                         	   50000	     23286 ns/op	    5416 B/op	     223 allocs/op
+BenchmarkComplexArrayStructAllTypesGorillaParallel-4                 	  200000	      6773 ns/op	    5416 B/op	     223 allocs/op
+BenchmarkArrayMapNestedStructGorilla-4                               	  200000	      7745 ns/op	    2285 B/op	      75 allocs/op
+BenchmarkArrayMapNestedStructGorillaParallel-4                       	  500000	      2421 ns/op	    2285 B/op	      75 allocs/op
 ```
 
 ### monoculum/formam
 ```go
-BenchmarkSimpleUserStructFormam-8                                      	  500000       	      2311 ns/op       	     232 B/op  	      16 allocs/op
-BenchmarkSimpleUserStructFormamParallel-8                              	 2000000       	       793 ns/op       	     232 B/op  	      16 allocs/op
-BenchmarkPrimitivesStructAllPrimitivesFormamTypes-8                    	  200000       	      8539 ns/op       	    1088 B/op  	     121 allocs/op
-BenchmarkPrimitivesStructAllPrimitivesTypesFormamParallel-8            	 1000000       	      2876 ns/op       	    1088 B/op  	     121 allocs/op
-BenchmarkComplexArrayStructAllTypesFormam-8                            	   50000       	     37409 ns/op       	    5608 B/op  	     485 allocs/op
-BenchmarkComplexArrayStructAllTypesFormamParallel-8                    	  200000       	     12292 ns/op       	    5556 B/op  	     482 allocs/op
-BenchmarkComplexMapStructAllTypesFormam-8                              	   30000       	     41450 ns/op       	   14647 B/op  	     534 allocs/op
-BenchmarkComplexMapStructAllTypesFormamParallel-8                      	  100000       	     14764 ns/op       	   14647 B/op  	     534 allocs/op
+BenchmarkSimpleUserStructFormam-4                                    	 1000000	      1927 ns/op	     232 B/op	      16 allocs/op
+BenchmarkSimpleUserStructFormamParallel-4                            	 3000000	       514 ns/op	     232 B/op	      16 allocs/op
+BenchmarkPrimitivesStructAllPrimitivesFormamTypes-4                  	  200000	      7135 ns/op	    1088 B/op	     121 allocs/op
+BenchmarkPrimitivesStructAllPrimitivesTypesFormamParallel-4          	 1000000	      1870 ns/op	    1088 B/op	     121 allocs/op
+BenchmarkComplexArrayStructAllTypesFormam-4                          	   50000	     30957 ns/op	    5608 B/op	     485 allocs/op
+BenchmarkComplexArrayStructAllTypesFormamParallel-4                  	  200000	      8848 ns/op	    5594 B/op	     484 allocs/op
+BenchmarkComplexMapStructAllTypesFormam-4                            	   50000	     37984 ns/op	   14647 B/op	     534 allocs/op
+BenchmarkComplexMapStructAllTypesFormamParallel-4                    	  200000	      9795 ns/op	   14658 B/op	     534 allocs/op
 --- FAIL: BenchmarkArrayMapNestedStructFormam
-       	formam_test.go:137: formam: not supported type for field "Value" in path "NestedPtrArray[0].Value". Maybe you should to include it the UnmarshalText interface or register it using custom type?
+	formam_test.go:137: formam: not supported type for field "Value" in path "NestedPtrArray[0].Value". Maybe you should to include it the UnmarshalText interface or register it using custom type?
 --- FAIL: BenchmarkArrayMapNestedStructFormamParallel
-       	formam_test.go:151: formam: not supported type for field "Value" in path "NestedPtrArray[0].Value". Maybe you should to include it the UnmarshalText interface or register it using custom type?
+	formam_test.go:151: formam: not supported type for field "Value" in path "NestedPtrArray[0].Value". Maybe you should to include it the UnmarshalText interface or register it using custom type?
 ```
 
 ### ajg/form
 ```go
-BenchmarkSimpleUserDecodeStructAGJForm-8                               	  200000       	      6201 ns/op       	    1336 B/op  	      42 allocs/op
-BenchmarkSimpleUserDecodeStructParallelAGJFrom-8                       	 1000000       	      1728 ns/op       	    1336 B/op  	      42 allocs/op
-BenchmarkSimpleUserEncodeStructAGJForm-8                               	  300000       	      4969 ns/op       	    1304 B/op  	      37 allocs/op
-BenchmarkSimpleUserEncodeStructParallelAGJForm-8                       	 1000000       	      1431 ns/op       	    1304 B/op  	      37 allocs/op
-BenchmarkPrimitivesDecodeStructAllPrimitivesTypesAGJForm-8             	  100000       	     21879 ns/op       	    5718 B/op  	     171 allocs/op
-BenchmarkPrimitivesDecodeStructAllPrimitivesTypesParallelAGJForm-8     	  300000       	      6298 ns/op       	    5718 B/op  	     171 allocs/op
-BenchmarkPrimitivesEncodeStructAllPrimitivesTypesAGJForm-8             	  100000       	     17249 ns/op       	    5904 B/op  	     110 allocs/op
-BenchmarkPrimitivesEncodeStructAllPrimitivesTypesParallelAGJForm-8     	  300000       	      5032 ns/op       	    5904 B/op  	     110 allocs/op
+BenchmarkSimpleUserDecodeStructAGJForm-4                             	  300000	      5150 ns/op	    1336 B/op	      42 allocs/op
+BenchmarkSimpleUserDecodeStructParallelAGJFrom-4                     	 1000000	      1372 ns/op	    1336 B/op	      42 allocs/op
+BenchmarkSimpleUserEncodeStructAGJForm-4                             	  300000	      4196 ns/op	    1304 B/op	      37 allocs/op
+BenchmarkSimpleUserEncodeStructParallelAGJForm-4                     	 1000000	      1129 ns/op	    1304 B/op	      37 allocs/op
+BenchmarkPrimitivesDecodeStructAllPrimitivesTypesAGJForm-4           	  100000	     18605 ns/op	    5718 B/op	     171 allocs/op
+BenchmarkPrimitivesDecodeStructAllPrimitivesTypesParallelAGJForm-4   	  300000	      4941 ns/op	    5718 B/op	     171 allocs/op
+BenchmarkPrimitivesEncodeStructAllPrimitivesTypesAGJForm-4           	  100000	     14417 ns/op	    5903 B/op	     110 allocs/op
+BenchmarkPrimitivesEncodeStructAllPrimitivesTypesParallelAGJForm-4   	  500000	      3702 ns/op	    5904 B/op	     110 allocs/op
 --- FAIL: BenchmarkComplexArrayDecodeStructAllTypesAGJForm
-       	ajg_form_test.go:127:  is not a valid index for type []int16
+	ajg_form_test.go:127:  is not a valid index for type []uint32
 --- FAIL: BenchmarkComplexArrayDecodeStructAllTypesParallelAGJForm
-       	ajg_form_test.go:140:  is not a valid index for type []*string
-BenchmarkComplexArrayEncodeStructAllTypesAGJForm-8                     	   20000       	     75231 ns/op       	   22195 B/op  	     538 allocs/op
-BenchmarkComplexArrayEncodeStructAllTypesParallelAGJForm-8             	  100000       	     25228 ns/op       	   22199 B/op  	     538 allocs/op
-BenchmarkComplexMapDecodeStructAllTypesAGJForm-8                       	   10000       	    100451 ns/op       	   22496 B/op  	     692 allocs/op
-BenchmarkComplexMapDecodeStructAllTypesParallelAGJForm-8               	   50000       	     29669 ns/op       	   22496 B/op  	     692 allocs/op
-BenchmarkComplexMapEncodeStructAllTypesAGJForm-8                       	   30000       	     50423 ns/op       	   18288 B/op  	     419 allocs/op
-BenchmarkComplexMapEncodeStructAllTypesParallelAGJForm-8               	  100000       	     16833 ns/op       	   18289 B/op  	     419 allocs/op
+	ajg_form_test.go:140: Int8Ptr[1] doesn't exist in benchmarks.ComplexArrayStruct
+BenchmarkComplexArrayEncodeStructAllTypesAGJForm-4                   	   30000	     61548 ns/op	   22195 B/op	     538 allocs/op
+BenchmarkComplexArrayEncodeStructAllTypesParallelAGJForm-4           	  100000	     16386 ns/op	   22193 B/op	     538 allocs/op
+BenchmarkComplexMapDecodeStructAllTypesAGJForm-4                     	   20000	     76838 ns/op	   22498 B/op	     692 allocs/op
+BenchmarkComplexMapDecodeStructAllTypesParallelAGJForm-4             	  100000	     20941 ns/op	   22496 B/op	     692 allocs/op
+BenchmarkComplexMapEncodeStructAllTypesAGJForm-4                     	   50000	     40160 ns/op	   18286 B/op	     419 allocs/op
+BenchmarkComplexMapEncodeStructAllTypesParallelAGJForm-4             	  200000	     10761 ns/op	   18289 B/op	     419 allocs/op
 --- FAIL: BenchmarkDecodeNestedStructAGJForm
-       	ajg_form_test.go:261: NestedArray[0] doesn't exist in benchmarks.NestedStruct
+	ajg_form_test.go:261: NestedArray[0] doesn't exist in benchmarks.NestedStruct
 --- FAIL: BenchmarkDecodeNestedStructParallelAGJForm
-       	ajg_form_test.go:275: NestedPtrArray[0] doesn't exist in benchmarks.NestedStruct
-BenchmarkEncodeNestedStructAGJForm-8                                   	  100000       	     18447 ns/op       	    5838 B/op  	     147 allocs/op
-BenchmarkEncodeNestedStructParallelAGJForm-8                           	  300000       	      6898 ns/op       	    5838 B/op  	     147 allocs/op
+	ajg_form_test.go:275: NestedArray[0] doesn't exist in benchmarks.NestedStruct
+BenchmarkEncodeNestedStructAGJForm-4                                 	  100000	     15989 ns/op	    5838 B/op	     147 allocs/op
+BenchmarkEncodeNestedStructParallelAGJForm-4                         	  300000	      4272 ns/op	    5838 B/op	     147 allocs/op
 ```

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -3,6 +3,8 @@ package form
 import (
 	"errors"
 	"net/url"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1254,4 +1256,33 @@ func TestEncoderExplicit(t *testing.T) {
 	Equal(t, err, nil)
 	Equal(t, len(values), 1)
 	Equal(t, values["Name"][0], "Joeybloggs")
+}
+
+func TestEncoderRegisterTagNameFunc(t *testing.T) {
+
+	type Test struct {
+		Name string `json:"name"`
+		Age  int    `json:"-"`
+	}
+
+	test := &Test{
+		Name: "Joeybloggs",
+		Age:  3,
+	}
+
+	encoder := NewEncoder()
+	encoder.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name := fld.Tag.Get("json")
+
+		if commaIndex := strings.Index(name, ","); commaIndex != -1 {
+			name = name[:commaIndex]
+		}
+
+		return name
+	})
+
+	values, err := encoder.Encode(test)
+	Equal(t, err, nil)
+	Equal(t, len(values), 1)
+	Equal(t, values["name"][0], "Joeybloggs")
 }

--- a/form_decoder.go
+++ b/form_decoder.go
@@ -112,6 +112,16 @@ func (d *Decoder) SetMaxArraySize(size uint) {
 	d.maxArraySize = int(size)
 }
 
+// RegisterTagNameFunc registers a custom tag name parser function
+// NOTE: This method is not thread-safe it is intended that these all be registered prior to any parsing
+//
+// ADDITIONAL: once a custom function has been registered the default, or custom set, tag name is ignored
+// and relies 100% on the function for the name data. The return value WILL BE CACHED and so return value
+// must be consistent.
+func (d *Decoder) RegisterTagNameFunc(fn TagNameFunc) {
+	d.structCache.tagFn = fn
+}
+
 // RegisterCustomTypeFunc registers a CustomTypeFunc against a number of types.
 // NOTE: This method is not thread-safe it is intended that these all be registered prior to any parsing
 //

--- a/form_encoder.go
+++ b/form_encoder.go
@@ -82,6 +82,16 @@ func (e *Encoder) SetMode(mode Mode) {
 	e.mode = mode
 }
 
+// RegisterTagNameFunc registers a custom tag name parser function
+// NOTE: This method is not thread-safe it is intended that these all be registered prior to any parsing
+//
+// ADDITIONAL: once a custom function has been registered the default, or custom set, tag name is ignored
+// and relies 100% on the function for the name data. The return value WILL BE CACHED and so return value
+// must be consistent.
+func (e *Encoder) RegisterTagNameFunc(fn TagNameFunc) {
+	e.structCache.tagFn = fn
+}
+
 // RegisterCustomTypeFunc registers a CustomTypeFunc against a number of types
 // NOTE: this method is not thread-safe it is intended that these all be registered prior to any parsing
 func (e *Encoder) RegisterCustomTypeFunc(fn EncodeCustomTypeFunc, types ...interface{}) {


### PR DESCRIPTION
Added a new function to both the Decoder and Encoder called `RegisterTagNameFunc`.

#### NOTES:

Once a custom function has been registered the default, or custom set, tag name is ignored and relies 100% on the function for the name data.

The return value **WILL BE CACHED** and so return value must be consistent.