### PR TITLE
Add setting use brackets as a namespace separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 old.txt
 new.txt
+
+/.idea

--- a/decoder.go
+++ b/decoder.go
@@ -159,8 +159,9 @@ func (d *decoder) traverseStruct(v reflect.Value, typ reflect.Type, namespace []
 		if first {
 			namespace = append(namespace, f.name...)
 		} else {
-			namespace = append(namespace, namespaceSeparator)
+			namespace = append(namespace, d.d.namespacePrefix...)
 			namespace = append(namespace, f.name...)
+			namespace = append(namespace, d.d.namespaceSuffix...)
 		}
 
 		if d.setFieldByType(v.Field(f.idx), namespace, 0) {

--- a/encoder.go
+++ b/encoder.go
@@ -59,8 +59,9 @@ func (e *encoder) traverseStruct(v reflect.Value, namespace []byte, idx int) {
 		if first {
 			namespace = append(namespace, f.name...)
 		} else {
-			namespace = append(namespace, namespaceSeparator)
+			namespace = append(namespace, e.e.namespacePrefix...)
 			namespace = append(namespace, f.name...)
+			namespace = append(namespace, e.e.namespaceSuffix...)
 		}
 
 		e.setFieldByType(v.Field(f.idx), namespace, idx, f.isOmitEmpty)

--- a/form.go
+++ b/form.go
@@ -6,11 +6,10 @@ import (
 )
 
 const (
-	blank              = ""
-	namespaceSeparator = '.'
-	ignore             = "-"
-	fieldNS            = "Field Namespace:"
-	errorText          = " ERROR:"
+	blank     = ""
+	ignore    = "-"
+	fieldNS   = "Field Namespace:"
+	errorText = " ERROR:"
 )
 
 var (

--- a/form_decoder.go
+++ b/form_decoder.go
@@ -69,16 +69,19 @@ type Decoder struct {
 	customTypeFuncs map[reflect.Type]DecodeCustomTypeFunc
 	maxArraySize    int
 	dataPool        *sync.Pool
+	namespacePrefix string
+	namespaceSuffix string
 }
 
 // NewDecoder creates a new decoder instance with sane defaults
 func NewDecoder() *Decoder {
 
 	d := &Decoder{
-		tagName:      "form",
-		mode:         ModeImplicit,
-		structCache:  newStructCacheMap(),
-		maxArraySize: 10000,
+		tagName:         "form",
+		mode:            ModeImplicit,
+		structCache:     newStructCacheMap(),
+		maxArraySize:    10000,
+		namespacePrefix: ".",
 	}
 
 	d.dataPool = &sync.Pool{New: func() interface{} {
@@ -101,6 +104,16 @@ func (d *Decoder) SetTagName(tagName string) {
 // Default is ModeImplicit
 func (d *Decoder) SetMode(mode Mode) {
 	d.mode = mode
+}
+
+// SetNamespacePrefix sets a struct namespace prefix.
+func (d *Decoder) SetNamespacePrefix(namespacePrefix string) {
+	d.namespacePrefix = namespacePrefix
+}
+
+// SetNamespaceSuffix sets a struct namespace suffix.
+func (d *Decoder) SetNamespaceSuffix(namespaceSuffix string) {
+	d.namespaceSuffix = namespaceSuffix
 }
 
 // SetMaxArraySize sets maximum array size that can be created.

--- a/form_encoder.go
+++ b/form_encoder.go
@@ -50,16 +50,19 @@ type Encoder struct {
 	dataPool        *sync.Pool
 	mode            Mode
 	embedAnonymous  bool
+	namespacePrefix string
+	namespaceSuffix string
 }
 
 // NewEncoder creates a new encoder instance with sane defaults
 func NewEncoder() *Encoder {
 
 	e := &Encoder{
-		tagName:        "form",
-		mode:           ModeImplicit,
-		structCache:    newStructCacheMap(),
-		embedAnonymous: true,
+		tagName:         "form",
+		mode:            ModeImplicit,
+		structCache:     newStructCacheMap(),
+		embedAnonymous:  true,
+		namespacePrefix: ".",
 	}
 
 	e.dataPool = &sync.Pool{New: func() interface{} {
@@ -82,6 +85,16 @@ func (e *Encoder) SetTagName(tagName string) {
 // Default is ModeImplicit
 func (e *Encoder) SetMode(mode Mode) {
 	e.mode = mode
+}
+
+// SetNamespacePrefix sets a struct namespace prefix.
+func (e *Encoder) SetNamespacePrefix(namespacePrefix string) {
+	e.namespacePrefix = namespacePrefix
+}
+
+// SetNamespaceSuffix sets a struct namespace suffix.
+func (e *Encoder) SetNamespaceSuffix(namespaceSuffix string) {
+	e.namespaceSuffix = namespaceSuffix
 }
 
 // SetAnonymousMode sets the mode the encoder should run


### PR DESCRIPTION
## Add a new setting that allows using square brackets as a namespace separator. 

In a company I work for we use square brackets as a struct separator.

- [*] Tests exist or have been written that cover this particular change.

@go-playground/admins