### PR TITLE
Fix panic when we encode uncomparable fields with omitempty tag

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1333,6 +1333,10 @@ func TestEncoderEmbedModes(t *testing.T) {
 
 func TestOmitEmpty(t *testing.T) {
 
+	type NotComparable struct {
+		Slice []string
+	}
+
 	type Test struct {
 		String  string            `form:",omitempty"`
 		Array   []string          `form:",omitempty"`
@@ -1340,6 +1344,7 @@ func TestOmitEmpty(t *testing.T) {
 		String2 string            `form:"str,omitempty"`
 		Array2  []string          `form:"arr,omitempty"`
 		Map2    map[string]string `form:"map,omitempty"`
+		NotComparable			  `form:",omitempty"`
 	}
 
 	var tst Test

--- a/util.go
+++ b/util.go
@@ -51,6 +51,12 @@ func hasValue(field reflect.Value) bool {
 	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
 		return !field.IsNil()
 	default:
-		return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
+		if !field.IsValid() {
+			return false
+		}
+		if !field.Type().Comparable() {
+			return true
+		}
+		return field.Interface() != reflect.Zero(field.Type()).Interface()
 	}
 }


### PR DESCRIPTION
When we tell a form to omit empty fields using `,omitempty` for uncomparable fields we get panic. 

Example:

```golang
func main() {
	type nestedStruct struct {
		Slice []string
	}

	type testStruct struct {
		NestedStruct nestedStruct `form:",omitempty"`
	}

	form.NewEncoder().Encode(&testStruct{})
}
```

```plain
panic: runtime error: comparing uncomparable type main.nestedStruct
```

The reason for this is because we are trying to compare uncomparable fields here:
https://github.com/go-playground/form/blob/master/util.go#L54-L54

- [*] Tests exist or have been written that cover this particular change.

@go-playground/admins