### PR TITLE
Enhancement: `form.Marshaler` and `form.Unmarshaler`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It has the following features:
 
 Common Questions
 
-- Does it support encoding.TextUnmarshaler? No because TextUnmarshaler only accepts []byte but posted values can have multiple values, so is not suitable.
+- Does it support encoding.TextUnmarshaler? No, instead we have `form.Unmarshaler` because TextUnmarshaler only accepts []byte but posted values can have multiple values, so is not suitable.
 - Mixing `array/slice` with `array[idx]/slice[idx]`, in which order are they parsed? `array/slice` then `array[idx]/slice[idx]`
 
 Supported Types ( out of the box )
@@ -228,6 +228,33 @@ Encoder
 encoder.RegisterCustomTypeFunc(func(x interface{}) ([]string, error) {
 	return []string{x.(time.Time).Format("2006-01-02")}, nil
 }, time.Time{})
+```
+
+Implementing Marshaler and Unmarshaler
+--------------
+Marshaler
+```go
+type CustomStruct struct {
+    A string
+    B string
+}
+
+func (c CustomStruct) MarshalForm() ([]string, error) {
+    return []string{ c.A, c.B }, nil
+}
+```
+
+Unmarshaler
+```go
+type CustomStruct struct {
+    A string
+    B string
+}
+
+func (c *CustomStruct) UnmarshalForm(ss []string) error {
+    c.A = ss[0]
+    c.B = ss[1]
+}
 ```
 
 Ignoring Fields

--- a/decoder.go
+++ b/decoder.go
@@ -782,7 +782,8 @@ func (d *decoder) unmarshal(v reflect.Value, idx int, arr []string) (bool, error
 
 func (d *decoder) unmarshalAddr(v reflect.Value, idx int, arr []string) (bool, error) {
 	nv := reflect.New(v.Type().Elem())
-	if err := nv.Interface().(Unmarshaler).UnmarshalForm(arr[idx:]); err != nil {
+	um := nv.Interface().(Unmarshaler)
+	if err := um.UnmarshalForm(arr[idx:]); err != nil {
 		return false, err
 	}
 	v.Set(nv)

--- a/decoder.go
+++ b/decoder.go
@@ -202,7 +202,7 @@ func (d *decoder) setFieldByType(current reflect.Value, namespace []byte, idx in
 		}
 		if um, ok := v.Interface().(Unmarshaler); ok {
 			// if receiver is a nil pointer, set before calling function.
-			if t := v.Type(); t.Kind() == reflect.Ptr && v.IsNil() {
+			if t.Kind() == reflect.Ptr && v.IsNil() {
 				t = t.Elem()
 				v.Set(reflect.New(t))
 				um = v.Interface().(Unmarshaler)

--- a/decoder.go
+++ b/decoder.go
@@ -200,12 +200,12 @@ func (d *decoder) setFieldByType(current reflect.Value, namespace []byte, idx in
 		if t.Kind() != reflect.Ptr && v.CanAddr() {
 			v = v.Addr()
 		}
-		if um, ok := v.Interface().(FormUnmarshaler); ok {
+		if um, ok := v.Interface().(Unmarshaler); ok {
 			// if receiver is a nil pointer, set before calling function.
 			if t := v.Type(); t.Kind() == reflect.Ptr && v.IsNil() {
 				t = t.Elem()
 				v.Set(reflect.New(t))
-				um = v.Interface().(FormUnmarshaler)
+				um = v.Interface().(Unmarshaler)
 			}
 			if err = um.UnmarshalForm(arr[idx:]); err != nil {
 				d.setError(namespace, err)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -31,7 +31,6 @@ import (
 // go test -memprofile mem.out
 
 func TestDecoderInt(t *testing.T) {
-
 	type TestInt struct {
 		Int              int
 		Int8             int8
@@ -150,7 +149,6 @@ func TestDecoderInt(t *testing.T) {
 }
 
 func TestDecoderUint(t *testing.T) {
-
 	type TestUint struct {
 		Uint              uint
 		Uint8             uint8
@@ -269,7 +267,6 @@ func TestDecoderUint(t *testing.T) {
 }
 
 func TestDecoderString(t *testing.T) {
-
 	type TestString struct {
 		String              string
 		StringPtr           *string
@@ -353,7 +350,6 @@ func TestDecoderString(t *testing.T) {
 }
 
 func TestDecoderFloat(t *testing.T) {
-
 	type TestFloat struct {
 		Float32              float32
 		Float32Ptr           *float32
@@ -445,7 +441,6 @@ func TestDecoderFloat(t *testing.T) {
 }
 
 func TestDecoderBool(t *testing.T) {
-
 	type TestBool struct {
 		Bool              bool
 		BoolPtr           *bool
@@ -588,7 +583,6 @@ func TestDecoderEqualStructMapValue(t *testing.T) {
 }
 
 func TestDecoderStruct(t *testing.T) {
-
 	type Phone struct {
 		Number string
 	}
@@ -829,7 +823,6 @@ func TestDecoderStruct(t *testing.T) {
 }
 
 func TestDecoderNativeTime(t *testing.T) {
-
 	type TestError struct {
 		Time        time.Time
 		TimeNoValue time.Time
@@ -858,7 +851,6 @@ func TestDecoderNativeTime(t *testing.T) {
 }
 
 func TestDecoderErrors(t *testing.T) {
-
 	type TestError struct {
 		Bool                  bool `form:"bool"`
 		Int                   int
@@ -1074,7 +1066,6 @@ func TestDecoderErrors(t *testing.T) {
 }
 
 func TestDecodeAllTypes(t *testing.T) {
-
 	values := url.Values{
 		"": []string{"3"},
 	}
@@ -1297,7 +1288,6 @@ func TestDecodeAllTypes(t *testing.T) {
 }
 
 func TestDecoderPanicsAndBadValues(t *testing.T) {
-
 	type Phone struct {
 		Number string
 	}
@@ -1362,7 +1352,6 @@ func TestDecoderPanicsAndBadValues(t *testing.T) {
 }
 
 func TestDecoderMapKeys(t *testing.T) {
-
 	type TestMapKeys struct {
 		MapIfaceKey   map[interface{}]string
 		MapFloat32Key map[float32]float32
@@ -1434,7 +1423,6 @@ func TestDecoderMapKeys(t *testing.T) {
 }
 
 func TestDecoderStructRecursion(t *testing.T) {
-
 	type Nested struct {
 		Value  string
 		Nested *Nested
@@ -1498,11 +1486,9 @@ func TestDecoderStructRecursion(t *testing.T) {
 			Equal(t, test.NestedTwo.Nested.Value, "value")
 		})
 	}
-
 }
 
 func TestDecoderFormDecode(t *testing.T) {
-
 	type Struct2 struct {
 		Foo string
 		Bar string
@@ -1535,13 +1521,11 @@ func TestDecoderFormDecode(t *testing.T) {
 }
 
 func TestDecoderArrayKeysSort(t *testing.T) {
-
 	type Struct struct {
 		Array []int
 	}
 
 	values := map[string][]string{
-
 		"Array[2]":  {"2"},
 		"Array[10]": {"10"},
 	}
@@ -1559,7 +1543,6 @@ func TestDecoderArrayKeysSort(t *testing.T) {
 }
 
 func TestDecoderIncreasingKeys(t *testing.T) {
-
 	type Struct struct {
 		Array []int
 	}
@@ -1591,7 +1574,6 @@ func TestDecoderIncreasingKeys(t *testing.T) {
 }
 
 func TestDecoderInterface(t *testing.T) {
-
 	var iface interface{}
 
 	d := NewDecoder()
@@ -1644,7 +1626,6 @@ func TestDecoderInterface(t *testing.T) {
 }
 
 func TestDecoderPointerToPointer(t *testing.T) {
-
 	values := map[string][]string{
 		"Value": {"testVal"},
 	}
@@ -1662,7 +1643,6 @@ func TestDecoderPointerToPointer(t *testing.T) {
 }
 
 func TestDecoderExplicit(t *testing.T) {
-
 	type Test struct {
 		Name string `form:"Name"`
 		Age  int
@@ -1707,7 +1687,6 @@ func TestDecoderStructWithJSONTag(t *testing.T) {
 }
 
 func TestDecoderRegisterTagNameFunc(t *testing.T) {
-
 	type Test struct {
 		Value  string `json:"val,omitempty"`
 		Ignore string `json:"-"`
@@ -1738,7 +1717,6 @@ func TestDecoderRegisterTagNameFunc(t *testing.T) {
 }
 
 func TestDecoderEmbedModes(t *testing.T) {
-
 	type A struct {
 		Field string
 	}
@@ -1773,7 +1751,6 @@ func TestDecoderEmbedModes(t *testing.T) {
 }
 
 func TestInterfaceDecoding(t *testing.T) {
-
 	type Test struct {
 		Iface interface{}
 	}
@@ -1935,4 +1912,78 @@ func TestDecoder_InvalidSliceIndex(t *testing.T) {
 	Equal(t, len(v2.PostIds), 2)
 	Equal(t, v2.PostIds[0], "1")
 	Equal(t, v2.PostIds[1], "2")
+}
+
+type unmarshaler struct {
+	fname string
+	sname string
+}
+
+func (u *unmarshaler) UnmarshalForm(ss []string) error {
+	if len(ss) != 2 {
+		return errors.New("invalid value")
+	}
+	u.fname = ss[0]
+	u.sname = ss[1]
+	return nil
+}
+
+func TestDecoder_UnmarshalForm(t *testing.T) {
+	type T1 struct {
+		Ptr    *unmarshaler
+		NilPtr *unmarshaler
+		Struct unmarshaler
+	}
+
+	in := url.Values{
+		"Ptr":    []string{"Liam", "Neeson"},
+		"NilPtr": []string{"John", "Smith"},
+		"Struct": []string{"Bob", "Dylan"},
+	}
+
+	v := new(T1)
+	v.Ptr = &unmarshaler{}
+	err := NewDecoder().Decode(v, in)
+	Equal(t, err, nil)
+	NotEqual(t, v.NilPtr, nil)
+	Equal(t, v.Ptr.fname, "Liam")
+	Equal(t, v.Ptr.sname, "Neeson")
+	Equal(t, v.NilPtr.fname, "John")
+	Equal(t, v.NilPtr.sname, "Smith")
+	Equal(t, v.Struct.fname, "Bob")
+	Equal(t, v.Struct.sname, "Dylan")
+}
+
+func TestDecoder_UnmarshalForm_Error(t *testing.T) {
+	in := url.Values{
+		"Ptr":    []string{"John"},
+		"NilPtr": []string{"John"},
+		"Struct": []string{"John"},
+	}
+	d := NewDecoder()
+
+	type t1 struct {
+		Ptr *unmarshaler
+	}
+	v1 := new(t1)
+	err := d.Decode(v1, in)
+	NotEqual(t, err, nil)
+	Equal(t, err.Error(), "Field Namespace:Ptr ERROR:invalid value")
+
+	type t2 struct {
+		NilPtr *unmarshaler
+	}
+
+	v2 := new(t2)
+	err = d.Decode(v2, in)
+	NotEqual(t, err, nil)
+	Equal(t, err.Error(), "Field Namespace:NilPtr ERROR:invalid value")
+
+	type t3 struct {
+		Struct unmarshaler
+	}
+	v3 := new(t3)
+	err = d.Decode(v3, in)
+	NotEqual(t, err, nil)
+	Equal(t, err.Error(), "Field Namespace:Struct ERROR:invalid value")
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1930,15 +1930,27 @@ func (u *unmarshaler) UnmarshalForm(ss []string) error {
 
 func TestDecoder_UnmarshalForm(t *testing.T) {
 	type T1 struct {
-		Ptr    *unmarshaler
-		NilPtr *unmarshaler
-		Struct unmarshaler
+		Ptr      *unmarshaler
+		NilPtr   *unmarshaler
+		Struct   unmarshaler
+		Slice    []unmarshaler
+		SlicePtr []*unmarshaler
+		Map      map[string]unmarshaler
+		MapPtr   map[string]*unmarshaler
 	}
 
 	in := url.Values{
-		"Ptr":    []string{"Liam", "Neeson"},
-		"NilPtr": []string{"John", "Smith"},
-		"Struct": []string{"Bob", "Dylan"},
+		"Ptr":          []string{"ptrfname", "ptrsname"},
+		"NilPtr":       []string{"nilptrfname", "nilptrsname"},
+		"Struct":       []string{"structfname", "structsname"},
+		"Slice[0]":     []string{"slice0fname", "slice0sname"},
+		"Slice[1]":     []string{"slice1fname", "slice1sname"},
+		"SlicePtr[0]":  []string{"sliceptr0fname", "sliceptr0sname"},
+		"SlicePtr[1]":  []string{"sliceptr1fname", "sliceptr1sname"},
+		"Map[key1]":    []string{"mapk1fname", "mapk1sname"},
+		"Map[key2]":    []string{"mapk2fname", "mapk2sname"},
+		"MapPtr[key1]": []string{"mapptrk1fname", "mapptrk1sname"},
+		"MapPtr[key2]": []string{"mapptrk2fname", "mapptrk2sname"},
 	}
 
 	v := new(T1)
@@ -1946,12 +1958,32 @@ func TestDecoder_UnmarshalForm(t *testing.T) {
 	err := NewDecoder().Decode(v, in)
 	Equal(t, err, nil)
 	NotEqual(t, v.NilPtr, nil)
-	Equal(t, v.Ptr.fname, "Liam")
-	Equal(t, v.Ptr.sname, "Neeson")
-	Equal(t, v.NilPtr.fname, "John")
-	Equal(t, v.NilPtr.sname, "Smith")
-	Equal(t, v.Struct.fname, "Bob")
-	Equal(t, v.Struct.sname, "Dylan")
+	Equal(t, v.Ptr.fname, "ptrfname")
+	Equal(t, v.Ptr.sname, "ptrsname")
+	Equal(t, v.NilPtr.fname, "nilptrfname")
+	Equal(t, v.NilPtr.sname, "nilptrsname")
+	Equal(t, v.Struct.fname, "structfname")
+	Equal(t, v.Struct.sname, "structsname")
+
+	Equal(t, len(v.Slice), 2)
+	Equal(t, v.Slice[0].fname, "slice0fname")
+	Equal(t, v.Slice[1].fname, "slice1fname")
+
+	Equal(t, len(v.SlicePtr), 2)
+	Equal(t, v.SlicePtr[0].fname, "sliceptr0fname")
+	Equal(t, v.SlicePtr[1].fname, "sliceptr1fname")
+
+	Equal(t, len(v.Map), 2)
+	Equal(t, v.Map["key1"].fname, "mapk1fname")
+	Equal(t, v.Map["key1"].sname, "mapk1sname")
+	Equal(t, v.Map["key2"].fname, "mapk2fname")
+	Equal(t, v.Map["key2"].sname, "mapk2sname")
+
+	Equal(t, len(v.MapPtr), 2)
+	Equal(t, v.MapPtr["key1"].fname, "mapptrk1fname")
+	Equal(t, v.MapPtr["key1"].sname, "mapptrk1sname")
+	Equal(t, v.MapPtr["key2"].fname, "mapptrk2fname")
+	Equal(t, v.MapPtr["key2"].sname, "mapptrk2sname")
 }
 
 func TestDecoder_UnmarshalForm_Error(t *testing.T) {

--- a/encoder.go
+++ b/encoder.go
@@ -103,7 +103,7 @@ func (e *encoder) setFieldByType(current reflect.Value, namespace []byte, idx in
 		if t := v.Type(); t.Kind() == reflect.Ptr && v.IsNil() {
 			return
 		}
-		if um, ok := v.Interface().(FormMarshaler); ok {
+		if um, ok := v.Interface().(Marshaler); ok {
 			vals, err := um.MarshalForm()
 			if err != nil {
 				e.setError(namespace, err)

--- a/encoder.go
+++ b/encoder.go
@@ -99,7 +99,6 @@ func (e *encoder) setFieldByType(current reflect.Value, namespace []byte, idx in
 		}
 	}
 	{
-		v := v // deliberately shadow v as to not modify
 		if t := v.Type(); t.Kind() == reflect.Ptr && v.IsNil() {
 			return
 		}

--- a/encoder.go
+++ b/encoder.go
@@ -274,7 +274,10 @@ func (e *encoder) marshal(namespace []byte, v reflect.Value, idx int) (bool, err
 	if t.Kind() == reflect.Ptr && v.IsNil() {
 		return false, nil
 	}
-	um := v.Interface().(Marshaler)
+	um, ok := v.Interface().(Marshaler)
+	if !ok {
+		return false, nil
+	}
 	vals, err := um.MarshalForm()
 	if err != nil {
 		return false, err

--- a/encoder.go
+++ b/encoder.go
@@ -265,13 +265,13 @@ func (e *encoder) getMapKey(key reflect.Value, namespace []byte) (string, bool) 
 
 func (e *encoder) marshal(namespace []byte, v reflect.Value, idx int) (bool, error) {
 	t := v.Type()
-	if t.Kind() != reflect.Pointer && v.CanAddr() && reflect.PointerTo(t).Implements(marshalerType) {
+	if t.Kind() != reflect.Ptr && v.CanAddr() && reflect.PtrTo(t).Implements(marshalerType) {
 		return e.marshalAddr(namespace, v, idx)
 	}
-	if !t.Implements(marshalerType) && !reflect.PointerTo(t).Implements(marshalerType) {
+	if !t.Implements(marshalerType) && !reflect.PtrTo(t).Implements(marshalerType) {
 		return false, nil
 	}
-	if t.Kind() == reflect.Pointer && v.IsNil() {
+	if t.Kind() == reflect.Ptr && v.IsNil() {
 		return false, nil
 	}
 	um := v.Interface().(Marshaler)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1613,38 +1613,64 @@ func Test_MarshalForm(t *testing.T) {
 		Struct   marshaler
 		Slice    []marshaler
 		SlicePtr []*marshaler
+		Map      map[string]marshaler
+		MapPtr   map[string]*marshaler
 	}{
 		Ptr: &marshaler{
-			Fname: "John",
-			Sname: "Smith",
+			Fname: "ptrfname",
+			Sname: "ptrsname",
 		},
 		Struct: marshaler{
-			Fname: "Bob",
-			Sname: "Dylan",
+			Fname: "structfname",
+			Sname: "structsname",
 		},
 		Slice: []marshaler{{
-			Fname: "Danny",
-			Sname: "Devito",
+			Fname: "slice1fname",
+			Sname: "slice1sname",
 		}, {
-			Fname: "Arnold",
-			Sname: "Schwarzenegger",
+			Fname: "slice2fname",
+			Sname: "slice2sname",
 		}},
 		SlicePtr: []*marshaler{{
-			Fname: "Mary-Kate",
-			Sname: "Olsen",
+			Fname: "sliceptr1fname",
+			Sname: "sliceptr1sname",
 		}, {
-			Fname: "Ashley",
-			Sname: "Olsen",
+			Fname: "sliceptr2fname",
+			Sname: "sliceptr2sname",
 		}},
+		Map: map[string]marshaler{
+			"key1": {
+				Fname: "mapk1fname",
+				Sname: "mapk1sname",
+			},
+			"key2": {
+				Fname: "mapk2fname",
+				Sname: "mapk2sname",
+			},
+		},
+		MapPtr: map[string]*marshaler{
+			"key1": {
+				Fname: "mapptrk1fname",
+				Sname: "mapptrk1sname",
+			},
+			"key2": {
+				Fname: "mapptrk2fname",
+				Sname: "mapptrk2sname",
+			},
+		},
 	}
 	values, err := NewEncoder().Encode(T1)
 	Equal(t, err, nil)
-	Equal(t, values["Ptr"], []string{"John", "Smith"})
+	Equal(t, values["Ptr"], []string{"ptrfname", "ptrsname"})
 	Equal(t, values["NilPointer"], nil)
-	Equal(t, values["Struct"], []string{"Bob", "Dylan"})
-	Equal(t, values["Slice"], []string{"Danny", "Devito", "Arnold", "Schwarzenegger"})
-	Equal(t, values["SlicePtr[0]"], []string{"Mary-Kate", "Olsen"})
-	Equal(t, values["SlicePtr[1]"], []string{"Ashley", "Olsen"})
+	Equal(t, values["Struct"], []string{"structfname", "structsname"})
+	Equal(t, values["Slice"], []string{"slice1fname", "slice1sname", "slice2fname", "slice2sname"})
+	Equal(t, values["SlicePtr[0]"], []string{"sliceptr1fname", "sliceptr1sname"})
+	Equal(t, values["SlicePtr[1]"], []string{"sliceptr2fname", "sliceptr2sname"})
+	Equal(t, values["Map[key1]"], []string{"mapk1fname", "mapk1sname"})
+	Equal(t, values["Map[key2]"], []string{"mapk2fname", "mapk2sname"})
+	Equal(t, values["MapPtr[key1]"], []string{"mapptrk1fname", "mapptrk1sname"})
+	Equal(t, values["MapPtr[key2]"], []string{"mapptrk2fname", "mapptrk2sname"})
 }
 
 type errmarshaler struct {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1709,8 +1709,8 @@ func Test_MarshalForm_Err(t *testing.T) {
 		Struct errmarshaler
 	}{
 		Struct: errmarshaler{
-			Fname: "Bob",
-			Sname: "Dylan",
+			Fname: "John",
+			Sname: "Smith",
 		},
 	}
 	v3, err := encoder.Encode(t3)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1625,18 +1625,18 @@ func Test_MarshalForm(t *testing.T) {
 			Sname: "structsname",
 		},
 		Slice: []marshaler{{
+			Fname: "slice0fname",
+			Sname: "slice0sname",
+		}, {
 			Fname: "slice1fname",
 			Sname: "slice1sname",
-		}, {
-			Fname: "slice2fname",
-			Sname: "slice2sname",
 		}},
 		SlicePtr: []*marshaler{{
+			Fname: "sliceptr0fname",
+			Sname: "sliceptr0sname",
+		}, {
 			Fname: "sliceptr1fname",
 			Sname: "sliceptr1sname",
-		}, {
-			Fname: "sliceptr2fname",
-			Sname: "sliceptr2sname",
 		}},
 		Map: map[string]marshaler{
 			"key1": {
@@ -1664,9 +1664,9 @@ func Test_MarshalForm(t *testing.T) {
 	Equal(t, values["Ptr"], []string{"ptrfname", "ptrsname"})
 	Equal(t, values["NilPointer"], nil)
 	Equal(t, values["Struct"], []string{"structfname", "structsname"})
-	Equal(t, values["Slice"], []string{"slice1fname", "slice1sname", "slice2fname", "slice2sname"})
-	Equal(t, values["SlicePtr[0]"], []string{"sliceptr1fname", "sliceptr1sname"})
-	Equal(t, values["SlicePtr[1]"], []string{"sliceptr2fname", "sliceptr2sname"})
+	Equal(t, values["Slice"], []string{"slice0fname", "slice0sname", "slice1fname", "slice1sname"})
+	Equal(t, values["SlicePtr[0]"], []string{"sliceptr0fname", "sliceptr0sname"})
+	Equal(t, values["SlicePtr[1]"], []string{"sliceptr1fname", "sliceptr1sname"})
 	Equal(t, values["Map[key1]"], []string{"mapk1fname", "mapk1sname"})
 	Equal(t, values["Map[key2]"], []string{"mapk2fname", "mapk2sname"})
 	Equal(t, values["MapPtr[key1]"], []string{"mapptrk1fname", "mapptrk1sname"})

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -29,7 +29,6 @@ import (
 // go test -memprofile mem.out
 
 func TestEncoderInt(t *testing.T) {
-
 	type TestInt struct {
 		Int              int
 		Int8             int8
@@ -194,7 +193,6 @@ func TestEncoderInt(t *testing.T) {
 }
 
 func TestEncoderUint(t *testing.T) {
-
 	type TestUint struct {
 		Uint              uint
 		Uint8             uint8
@@ -360,7 +358,6 @@ func TestEncoderUint(t *testing.T) {
 }
 
 func TestEncoderString(t *testing.T) {
-
 	type TestString struct {
 		String              string
 		StringPtr           *string
@@ -487,7 +484,6 @@ func TestEncoderString(t *testing.T) {
 }
 
 func TestEncoderFloat(t *testing.T) {
-
 	type TestFloat struct {
 		Float32              float32
 		Float32Ptr           *float32
@@ -706,7 +702,6 @@ func TestEncoderFloat(t *testing.T) {
 }
 
 func TestEncoderBool(t *testing.T) {
-
 	type TestBool struct {
 		Bool              bool
 		BoolPtr           *bool
@@ -820,7 +815,6 @@ func TestEncoderBool(t *testing.T) {
 }
 
 func TestEncoderStruct(t *testing.T) {
-
 	type Phone struct {
 		Number string
 	}
@@ -1019,7 +1013,6 @@ func TestEncoderStruct(t *testing.T) {
 }
 
 func TestEncoderStructCustomNamespace(t *testing.T) {
-
 	type Phone struct {
 		Number string
 	}
@@ -1237,7 +1230,6 @@ func TestEncoderMap(t *testing.T) {
 }
 
 func TestDecodeAllNonStructTypes(t *testing.T) {
-
 	encoder := NewEncoder()
 
 	// test integers
@@ -1351,7 +1343,6 @@ func TestDecodeAllNonStructTypes(t *testing.T) {
 }
 
 func TestEncoderNativeTime(t *testing.T) {
-
 	type TestError struct {
 		Time        time.Time
 		TimeNoValue time.Time
@@ -1378,7 +1369,6 @@ func TestEncoderNativeTime(t *testing.T) {
 }
 
 func TestEncoderErrors(t *testing.T) {
-
 	tm, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
 	Equal(t, err, nil)
 
@@ -1422,7 +1412,6 @@ func TestEncoderErrors(t *testing.T) {
 }
 
 func TestEncoderPanicsAndBadValues(t *testing.T) {
-
 	encoder := NewEncoder()
 
 	values, err := encoder.Encode(nil)
@@ -1449,7 +1438,6 @@ func TestEncoderPanicsAndBadValues(t *testing.T) {
 }
 
 func TestEncoderExplicit(t *testing.T) {
-
 	type Test struct {
 		Name string `form:"Name"`
 		Age  int
@@ -1470,7 +1458,6 @@ func TestEncoderExplicit(t *testing.T) {
 }
 
 func TestEncoderRegisterTagNameFunc(t *testing.T) {
-
 	type Test struct {
 		Name string `json:"name"`
 		Age  int    `json:"-"`
@@ -1499,7 +1486,6 @@ func TestEncoderRegisterTagNameFunc(t *testing.T) {
 }
 
 func TestEncoderEmbedModes(t *testing.T) {
-
 	type A struct {
 		Field string
 	}
@@ -1533,19 +1519,18 @@ func TestEncoderEmbedModes(t *testing.T) {
 }
 
 func TestOmitEmpty(t *testing.T) {
-
 	type NotComparable struct {
 		Slice []string
 	}
 
 	type Test struct {
-		String  string            `form:",omitempty"`
-		Array   []string          `form:",omitempty"`
-		Map     map[string]string `form:",omitempty"`
-		String2 string            `form:"str,omitempty"`
-		Array2  []string          `form:"arr,omitempty"`
-		Map2    map[string]string `form:"map,omitempty"`
-		NotComparable			  `form:",omitempty"`
+		String        string            `form:",omitempty"`
+		Array         []string          `form:",omitempty"`
+		Map           map[string]string `form:",omitempty"`
+		String2       string            `form:"str,omitempty"`
+		Array2        []string          `form:"arr,omitempty"`
+		Map2          map[string]string `form:"map,omitempty"`
+		NotComparable `form:",omitempty"`
 	}
 
 	var tst Test
@@ -1606,4 +1591,36 @@ func TestOmitEmpty(t *testing.T) {
 	Equal(t, len(values), 2)
 	Equal(t, values["x"][0], "0")
 	Equal(t, values["arr[0]"][0], "")
+}
+
+type marshaler struct {
+	Fname string
+	Sname string
+}
+
+func (m marshaler) MarshalForm() ([]string, error) {
+	return []string{
+		m.Fname,
+		m.Sname,
+	}, nil
+}
+
+func Test_MarshalForm(t *testing.T) {
+	T1 := struct {
+		Ptr    *marshaler
+		Struct marshaler
+	}{
+		Ptr: &marshaler{
+			Fname: "John",
+			Sname: "Smith",
+		},
+		Struct: marshaler{
+			Fname: "Bob",
+			Sname: "Dylan",
+		},
+	}
+	values, err := NewEncoder().Encode(T1)
+	Equal(t, err, nil)
+	Equal(t, values["Ptr"], []string{"John", "Smith"})
+	Equal(t, values["Struct"], []string{"Bob", "Dylan"})
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1611,7 +1611,7 @@ func Test_MarshalForm(t *testing.T) {
 		Ptr      *marshaler
 		NilPtr   *marshaler
 		Struct   marshaler
-		Slice    []*marshaler
+		Slice    []marshaler
 		SlicePtr []*marshaler
 	}{
 		Ptr: &marshaler{
@@ -1622,7 +1622,7 @@ func Test_MarshalForm(t *testing.T) {
 			Fname: "Bob",
 			Sname: "Dylan",
 		},
-		Slice: []*marshaler{{
+		Slice: []marshaler{{
 			Fname: "Danny",
 			Sname: "Devito",
 		}, {
@@ -1642,8 +1642,7 @@ func Test_MarshalForm(t *testing.T) {
 	Equal(t, values["Ptr"], []string{"John", "Smith"})
 	Equal(t, values["NilPointer"], nil)
 	Equal(t, values["Struct"], []string{"Bob", "Dylan"})
-	Equal(t, values["Slice[0]"], []string{"Danny", "Devito"})
-	Equal(t, values["Slice[1]"], []string{"Arnold", "Schwarzenegger"})
+	Equal(t, values["Slice"], []string{"Danny", "Devito", "Arnold", "Schwarzenegger"})
 	Equal(t, values["SlicePtr[0]"], []string{"Mary-Kate", "Olsen"})
 	Equal(t, values["SlicePtr[1]"], []string{"Ashley", "Olsen"})
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1608,9 +1608,11 @@ func (m marshaler) MarshalForm() ([]string, error) {
 
 func Test_MarshalForm(t *testing.T) {
 	T1 := struct {
-		Ptr    *marshaler
-		NilPtr *marshaler
-		Struct marshaler
+		Ptr      *marshaler
+		NilPtr   *marshaler
+		Struct   marshaler
+		Slice    []*marshaler
+		SlicePtr []*marshaler
 	}{
 		Ptr: &marshaler{
 			Fname: "John",
@@ -1620,12 +1622,30 @@ func Test_MarshalForm(t *testing.T) {
 			Fname: "Bob",
 			Sname: "Dylan",
 		},
+		Slice: []*marshaler{{
+			Fname: "Danny",
+			Sname: "Devito",
+		}, {
+			Fname: "Arnold",
+			Sname: "Schwarzenegger",
+		}},
+		SlicePtr: []*marshaler{{
+			Fname: "Mary-Kate",
+			Sname: "Olsen",
+		}, {
+			Fname: "Ashley",
+			Sname: "Olsen",
+		}},
 	}
 	values, err := NewEncoder().Encode(T1)
 	Equal(t, err, nil)
 	Equal(t, values["Ptr"], []string{"John", "Smith"})
 	Equal(t, values["NilPointer"], nil)
 	Equal(t, values["Struct"], []string{"Bob", "Dylan"})
+	Equal(t, values["Slice[0]"], []string{"Danny", "Devito"})
+	Equal(t, values["Slice[1]"], []string{"Arnold", "Schwarzenegger"})
+	Equal(t, values["SlicePtr[0]"], []string{"Mary-Kate", "Olsen"})
+	Equal(t, values["SlicePtr[1]"], []string{"Ashley", "Olsen"})
 }
 
 type errmarshaler struct {

--- a/form_decoder.go
+++ b/form_decoder.go
@@ -8,6 +8,11 @@ import (
 	"sync"
 )
 
+// FormUnmarshaler is the interface implemented by an object that can unmarshal a form representation of itself.
+type FormUnmarshaler interface {
+	UnmarshalForm(ss []string) error
+}
+
 // DecodeCustomTypeFunc allows for registering/overriding types to be parsed.
 type DecodeCustomTypeFunc func([]string) (interface{}, error)
 
@@ -35,7 +40,6 @@ type InvalidDecoderError struct {
 }
 
 func (e *InvalidDecoderError) Error() string {
-
 	if e.Type == nil {
 		return "form: Decode(nil)"
 	}
@@ -75,7 +79,6 @@ type Decoder struct {
 
 // NewDecoder creates a new decoder instance with sane defaults
 func NewDecoder() *Decoder {
-
 	d := &Decoder{
 		tagName:         "form",
 		mode:            ModeImplicit,
@@ -142,7 +145,6 @@ func (d *Decoder) RegisterTagNameFunc(fn TagNameFunc) {
 // the struct and not just the struct fields eg. url.Values{"User":"Name%3Djoeybloggs"} will call the
 // custom type function with `User` as the type, however url.Values{"User.Name":"joeybloggs"} will not.
 func (d *Decoder) RegisterCustomTypeFunc(fn DecodeCustomTypeFunc, types ...interface{}) {
-
 	if d.customTypeFuncs == nil {
 		d.customTypeFuncs = map[reflect.Type]DecodeCustomTypeFunc{}
 	}
@@ -156,7 +158,6 @@ func (d *Decoder) RegisterCustomTypeFunc(fn DecodeCustomTypeFunc, types ...inter
 //
 // Decode returns an InvalidDecoderError if interface passed is invalid.
 func (d *Decoder) Decode(v interface{}, values url.Values) (err error) {
-
 	val := reflect.ValueOf(v)
 
 	if val.Kind() != reflect.Ptr || val.IsNil() {

--- a/form_decoder.go
+++ b/form_decoder.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 )
 
-// FormUnmarshaler is the interface implemented by an object that can unmarshal a form representation of itself.
-type FormUnmarshaler interface {
+// Unmarshaler is the interface implemented by an object that can unmarshal a form representation of itself.
+type Unmarshaler interface {
 	UnmarshalForm(ss []string) error
 }
 

--- a/form_decoder.go
+++ b/form_decoder.go
@@ -10,7 +10,7 @@ import (
 
 // Unmarshaler is the interface implemented by an object that can unmarshal a form representation of itself.
 type Unmarshaler interface {
-	UnmarshalForm(ss []string) error
+	UnmarshalForm([]string) error
 }
 
 // DecodeCustomTypeFunc allows for registering/overriding types to be parsed.

--- a/form_encoder.go
+++ b/form_encoder.go
@@ -8,6 +8,11 @@ import (
 	"sync"
 )
 
+// FormMarshaler is the interface implemented by an object that can marshal itself into a textual form.
+type FormMarshaler interface {
+	MarshalForm() ([]string, error)
+}
+
 // EncodeCustomTypeFunc allows for registering/overriding types to be parsed.
 type EncodeCustomTypeFunc func(x interface{}) ([]string, error)
 
@@ -34,7 +39,6 @@ type InvalidEncodeError struct {
 }
 
 func (e *InvalidEncodeError) Error() string {
-
 	if e.Type == nil {
 		return "form: Encode(nil)"
 	}
@@ -56,7 +60,6 @@ type Encoder struct {
 
 // NewEncoder creates a new encoder instance with sane defaults
 func NewEncoder() *Encoder {
-
 	e := &Encoder{
 		tagName:         "form",
 		mode:            ModeImplicit,
@@ -116,7 +119,6 @@ func (e *Encoder) RegisterTagNameFunc(fn TagNameFunc) {
 // RegisterCustomTypeFunc registers a CustomTypeFunc against a number of types
 // NOTE: this method is not thread-safe it is intended that these all be registered prior to any parsing
 func (e *Encoder) RegisterCustomTypeFunc(fn EncodeCustomTypeFunc, types ...interface{}) {
-
 	if e.customTypeFuncs == nil {
 		e.customTypeFuncs = map[reflect.Type]EncodeCustomTypeFunc{}
 	}
@@ -128,7 +130,6 @@ func (e *Encoder) RegisterCustomTypeFunc(fn EncodeCustomTypeFunc, types ...inter
 
 // Encode encodes the given values and sets the corresponding struct values
 func (e *Encoder) Encode(v interface{}) (values url.Values, err error) {
-
 	val, kind := ExtractType(reflect.ValueOf(v))
 
 	if kind == reflect.Ptr || kind == reflect.Interface || kind == reflect.Invalid {

--- a/form_encoder.go
+++ b/form_encoder.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 )
 
-// FormMarshaler is the interface implemented by an object that can marshal itself into a textual form.
-type FormMarshaler interface {
+// Marshaler is the interface implemented by an object that can marshal itself into a textual form.
+type Marshaler interface {
 	MarshalForm() ([]string, error)
 }
 


### PR DESCRIPTION
## Fixes Or Enhances
Add support for custom marshalling and unmarshalling to a struct.

The motivation behind this mainly comes from using generics, when looking to register a custom encoder/decoder, you have to register one for every generic implementation of a struct, so for example:
```go
type MyGenericStruct[T any] struct {
    T T
}

decoder := form.NewDecoder()
decoder.RegisterCustomTypeFunc(func(x any) ([]string, error) {
    return // values
}, MyGenericStruct[Type1]{})
decoder.RegisterCustomTypeFunc(func(x any) ([]string, error) {
    return // values
}, MyGenericStruct[Type2]{})
// etc...
```

This isn't really great, so instead with these marshaller interfaces we can simply do:
```go
func (g *MyGenericStruct[T]) UnmarshalForm(ss []string) error {
    // Custom handling
    return nil
}

func (g MyGenericStruct[T]) MarshalForm() ([]string, error) {
    s := []string{}
    // build s
    return s, nil
}
```

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/admins