### PR TITLE
Fix panic when a custom type function returns nil for a pointer field

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -199,6 +199,11 @@ func (d *decoder) setFieldByType(current reflect.Value, namespace []byte, idx in
 					return
 				}
 
+				// Set would panic on the invalid zero Value, so nil leaves the field alone.
+				if val == nil {
+					return
+				}
+
 				v.Set(reflect.ValueOf(val))
 				set = true
 				return

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1881,6 +1881,36 @@ func TestDecoder_RegisterCustomTypeFunc(t *testing.T) {
 	Equal(t, v.Slice, []customString{"customv1", "customv2"})
 }
 
+func TestDecoder_CustomTypeFuncPointerNilValue(t *testing.T) {
+	type User struct {
+		Name string
+	}
+
+	type TestStruct struct {
+		U *User `form:"u"`
+	}
+
+	d := NewDecoder()
+	d.RegisterCustomTypeFunc(func(vals []string) (interface{}, error) {
+		if vals[0] == "" {
+			// "Leave the field at its zero value" must not panic on a pointer field.
+			return nil, nil
+		}
+		return &User{Name: vals[0]}, nil
+	}, &User{})
+
+	var empty TestStruct
+	err := d.Decode(&empty, url.Values{"u": {""}})
+	Equal(t, err, nil)
+	Equal(t, empty.U, nil)
+
+	var populated TestStruct
+	err = d.Decode(&populated, url.Values{"u": {"bob"}})
+	Equal(t, err, nil)
+	NotEqual(t, populated.U, nil)
+	Equal(t, populated.U.Name, "bob")
+}
+
 func TestDecoder_EmptyArrayString(t *testing.T) {
 	type T1 struct {
 		F1 string `form:"F1"`


### PR DESCRIPTION

## Problem

A `DecodeCustomTypeFunc` registered against a pointer type is a natural way
to say "there is no value, leave this pointer nil" by returning `nil, nil`
for an empty input (the `time.Time`-style workaround for "unset" is not
available for a custom pointer type). Doing that panics:

```go
type CustomTime *time.Time

type TestError struct {
    CT CustomTime
}

decoder := form.NewDecoder()
decoder.RegisterCustomTypeFunc(func(s []string) (interface{}, error) {
    if s[0] == "" {
        return nil, nil
    }
    parsed, err := time.Parse(time.RFC3339, s[0])
    if err != nil {
        return nil, err
    }
    return CustomTime(&parsed), nil
}, CustomTime(nil))

var test TestError
decoder.Decode(&test, url.Values{"CT": {""}})
```

```
panic: reflect: call of reflect.Value.Set on zero Value
```

## Root cause

`decoder.go:196-204`, inside the custom-type-function branch of
`setFieldByType`:

```go
val, err := cf(arr[idx:])
if err != nil {
    d.setError(namespace, err)
    return
}

v.Set(reflect.ValueOf(val))
```

When `cf` returns a nil `interface{}`, `reflect.ValueOf(val)` is the invalid
zero `reflect.Value`, and `Set` panics on it.

This exact bug was fixed once in #68, but that fix went through the generic
`case reflect.Ptr:` recursion path instead of guarding the nil case, which
discarded the custom function's own return value for a pointer type whenever
it returned something other than nil. That regressed the case where the
custom function itself returns a fully populated pointer (`&User{...}`), so
#68 was reverted in #69, and the original nil-pointer panic has been back on
master since.

## Fix

Guard against a nil `val` before calling `Set`, right where the value is
produced, instead of special-casing `reflect.Ptr` after the fact. A nil
return leaves the field at its existing zero value, everything else is set
exactly as before:

```go
if val == nil {
    return
}

v.Set(reflect.ValueOf(val))
```
