### PR TITLE
Respect native integer width when decoding form values

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -236,7 +236,7 @@ func (d *decoder) setFieldByType(current reflect.Value, namespace []byte, idx in
 			return
 		}
 		var u64 uint64
-		if u64, err = strconv.ParseUint(arr[idx], 10, 64); err != nil {
+		if u64, err = strconv.ParseUint(arr[idx], 10, v.Type().Bits()); err != nil {
 			d.setError(namespace, fmt.Errorf("Invalid Unsigned Integer Value '%s' Type '%v' Namespace '%s'", arr[idx], v.Type(), string(namespace)))
 			return
 		}
@@ -284,7 +284,7 @@ func (d *decoder) setFieldByType(current reflect.Value, namespace []byte, idx in
 			return
 		}
 		var i64 int64
-		if i64, err = strconv.ParseInt(arr[idx], 10, 64); err != nil {
+		if i64, err = strconv.ParseInt(arr[idx], 10, v.Type().Bits()); err != nil {
 			d.setError(namespace, fmt.Errorf("Invalid Integer Value '%s' Type '%v' Namespace '%s'", arr[idx], v.Type(), string(namespace)))
 			return
 		}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2100,5 +2101,46 @@ func BenchmarkNestedArrayDecode1000(b *testing.B) {
 		if err := decoder.Decode(&req, urlValues); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func TestDecodeNativeIntegerOverflow(t *testing.T) {
+	if strconv.IntSize != 32 {
+		t.Skip("native int and uint overflow below 64 bits only on 32-bit platforms")
+	}
+	for _, input := range []string{"2147483648", "-2147483649"} {
+		value := struct{ Value int }{Value: 7}
+		err := NewDecoder().Decode(&value, url.Values{"Value": []string{input}})
+		if err == nil {
+			t.Errorf("int %s: expected overflow error", input)
+		}
+		if value.Value != 7 {
+			t.Errorf("int %s: changed value to %d", input, value.Value)
+		}
+	}
+	value := struct{ Value uint }{Value: 7}
+	err := NewDecoder().Decode(&value, url.Values{"Value": []string{"4294967296"}})
+	if err == nil {
+		t.Error("uint: expected overflow error")
+	}
+	if value.Value != 7 {
+		t.Errorf("uint: changed value to %d", value.Value)
+	}
+
+	limits := struct {
+		Int    int
+		Uint   uint
+		Int64  int64
+		Uint64 uint64
+	}{}
+	err = NewDecoder().Decode(&limits, url.Values{
+		"Int": []string{"2147483647"}, "Uint": []string{"4294967295"},
+		"Int64": []string{"2147483648"}, "Uint64": []string{"4294967296"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limits.Int != 2147483647 || limits.Uint != 4294967295 || limits.Int64 != 2147483648 || limits.Uint64 != 4294967296 {
+		t.Errorf("boundary and 64-bit values changed: %+v", limits)
 	}
 }


### PR DESCRIPTION
This replaces https://github.com/go-playground/form/pull/78, which was accidentally closed and its source fork deleted. The implementation is unchanged; the original discussion and reviews remain linked there.

---

## Fixes Or Enhances

On 32-bit targets, decoding `2147483648` into `int` succeeds with `-2147483648`, and decoding `4294967296` into `uint` succeeds with zero. The shared int/int64 and uint/uint64 branches always parse with a 64-bit limit before reflection truncates the value.

Use the destination type's bit width for parsing. Regression tests verify both signed overflow directions, unsigned overflow, unchanged destination values on error, valid native boundaries, and values that still fit explicit 64-bit fields.

- [x] Tests exist or have been written that cover this particular change.

Validation: the three overflow cases fail on linux/386 before the fix. Full suites pass with `GOARCH=386 go test -cover ./...` and `go test -race -cover ./...` on amd64 (99.8% coverage). `go vet ./...` passes and golangci-lint reports no new issues.
